### PR TITLE
support custom url and servers responses without an ip address

### DIFF
--- a/noipy/main.py
+++ b/noipy/main.py
@@ -107,7 +107,7 @@ def execute_update(args):
                           "option.\nExecute noipy --help for more details."
 
     if update_ddns:
-        updater = provider_class(auth, args.hostname)
+        updater = provider_class(auth, args.hostname, args.url)
         ip_address = args.ip if args.ip else get_ip()
         print("Updating hostname '%s' with IP address %s ..."
               % (args.hostname, ip_address))
@@ -138,7 +138,7 @@ def create_parser():
     parser.add_argument('ip', metavar='IP_ADDRESS', nargs='?',
                         help="New host IP address. If not provided, current "
                              "external IP address will be used.")
-
+    parser.add_argument('--url', help="url of ddns service")
     return parser
 
 

--- a/test/test_noipy.py
+++ b/test/test_noipy.py
@@ -89,6 +89,20 @@ class PluginsTest(unittest.TestCase):
         self.assertTrue(status_message.startswith("ERROR:"),
                         "Status message should be an 'ERROR'")
 
+    def test_dyndns_plugin2(self):
+        cmd_args = ['-u', 'username', '-p', 'password',
+                    '-n', 'noipy.homelinux.com', '1.1.1.1',
+                    '--url', 'http://members.dyndns.org/nic/update']
+
+        args = self.parser.parse_args(cmd_args)
+        result, status_message = main.execute_update(args)
+
+        self.assertTrue(result == main.EXECUTION_RESULT_OK,
+                        "Result code should be %s " %
+                        main.EXECUTION_RESULT_OK)
+
+        self.assertTrue(status_message.startswith("ERROR:"),
+                        "Status message should be an 'ERROR'")
 
 class AuthInfoTest(unittest.TestCase):
 
@@ -172,7 +186,8 @@ class GeneralTest(unittest.TestCase):
     def test_not_implemented_plugin(self):
         auth = authinfo.ApiAuth('username', 'password')
         hostname = "hostname"
-        plugin = dnsupdater.DnsUpdaterPlugin(auth, hostname)
+        url = ""
+        plugin = dnsupdater.DnsUpdaterPlugin(auth, hostname, url)
         try:
             plugin.update_dns("1.1.1.1")
             self.fail("_get_base_url() should return NotImplemented")
@@ -186,7 +201,8 @@ class GeneralTest(unittest.TestCase):
     def test_dns_plugin_status_message(self):
         auth = authinfo.ApiAuth('username', 'password')
         hostname = "hostname"
-        plugin = dnsupdater.DnsUpdaterPlugin(auth, hostname)
+        url = ""
+        plugin = dnsupdater.DnsUpdaterPlugin(auth, hostname, url)
 
         # badauth code
         plugin.last_status_code = 'badauth'
@@ -201,6 +217,13 @@ class GeneralTest(unittest.TestCase):
                            "updated."
         self.assertTrue(plugin.status_message == expected_message,
                         "Expected 'good <1.1.1.1>' status code.")
+
+        # good code w/o IP
+        plugin.last_status_code = 'good'
+        expected_message = "SUCCESS: DNS hostname IP () successfully " \
+                           "updated."
+        self.assertTrue(plugin.status_message == expected_message,
+                        "Expected 'good' status code.")
 
         # nochg <IP> code
         plugin.last_status_code = 'nochg 1.1.1.1'


### PR DESCRIPTION
Hi,

These proposed modifications enable noipy to work with ddns servers that use the same protocols but are not run by the official providers and aren't at the standard addresses.  It does this by allowing you to specify a custom url on the command line with a "--url" argument.  The reason someone would want to do this is if they want to run their ddns on one of their own internet servers and have control over their dns records.

I also modified response message parsing to no longer crash in the event that a "good" or "nochg" message is received without an IP address, as is the case with this ddns server implementation: https://github.com/ianloic/dreamhost-ddns.

I included a couple of unit tests and they all pass.

Please let me know if I can be of any assistance,
Jay
