### PR TITLE
Handle httpbin as string instead of list

### DIFF
--- a/noipy/utils.py
+++ b/noipy/utils.py
@@ -26,8 +26,7 @@ def get_ip():
     """
     try:
         r = requests.get(HTTPBIN_URL)
-        ip, _ = r.json()['origin'].split(',')
-        return ip if r.status_code == 200 else None
+        return r.json()['origin'] if r.status_code == 200 else None
     except requests.exceptions.ConnectionError:
         return None
 


### PR DESCRIPTION
Revert back to the previous HTTPBIN response:
```
{
   "origin": "99.230.249.72"
}
```
