### PR TITLE
Add condition to upload OSSAR results

### DIFF
--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -44,6 +44,7 @@ jobs:
 
       # Upload results to the Security tab
     - name: Upload OSSAR results
+      if: ${{ github.event_name == 'pull_request' }}
       uses: github/codeql-action/upload-sarif@v1
       with:
         sarif_file: ${{ steps.ossar.outputs.sarifFile }}


### PR DESCRIPTION
Upload OSSAR results only for `pull_request` event.

Fixes [OSSAR Scan error](https://github.com/pv8/noipy/runs/6060208416?check_suite_focus=true):


```shell
Error: Workflows triggered by Dependabot on the "push" event run with read-only access. 
Uploading Code Scanning results requires write access. To use Code Scanning with 
Dependabot, please ensure you are using the "pull_request"  event for this workflow and 
avoid triggering on the "push" event for Dependabot branches.  
See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push 
for more information on how to configure these events.
``` 
