### PR TITLE
Modify test and utils.py to fix flaky test

### DIFF
--- a/noipy/utils.py
+++ b/noipy/utils.py
@@ -9,8 +9,6 @@ import socket
 
 import requests
 
-HTTPBIN_URL = 'https://httpbin.org/ip'
-
 try:
     input = raw_input
 except NameError:
@@ -21,10 +19,10 @@ def read_input(message):
     return input(message)
 
 
-def get_ip():
+def get_ip(httpbin_url):
     """Return machine's origin IP address."""
     try:
-        r = requests.get(HTTPBIN_URL)
+        r = requests.get(httpbin_url)
         return r.json()['origin'] if r.status_code == 200 else None
     except requests.exceptions.ConnectionError:
         return None

--- a/test/test_noipy.py
+++ b/test/test_noipy.py
@@ -31,14 +31,12 @@ class SanityTest(unittest.TestCase):
             shutil.rmtree(self.test_dir)
 
     def test_get_ip(self):
-        ip = utils.get_ip()
+        ip = utils.get_ip('https://httpbin.org/ip')
 
         self.assertTrue(re.match(VALID_IP_REGEX, ip), 'get_ip() failed.')
 
         # monkey patch for testing (forcing ConnectionError)
-        utils.HTTPBIN_URL = 'http://example.nothing'
-
-        ip = utils.get_ip()
+        ip = utils.get_ip('http://example.nothing')
         self.assertTrue(ip is None, 'get_ip() should return None. IP={}'.format(ip))
 
     def test_get_dns_ip(self):


### PR DESCRIPTION
The test `test_get_ip()` under the `SanityTest` class inside [`test_noipy.py`](https://github.com/pv8/noipy/blob/main/test/test_noipy.py) was found to be flaky, i.e. a test that both passes and fail despite no changes to the code or the tests itself.

Using the [pytest-flakefinder](https://github.com/dropbox/pytest-flakefinder) plugin, when the test was re-run more than once, it was failing. Upon looking at the code, the reason was because the the value of `HTTPBIN_URL` inside [`utils.py`](https://github.com/pv8/noipy/blob/main/noipy/utils.py) was not being set back to its default value of `https://httpbin.org/ip`

To fix it, I just changed the `test_get_ip()` test and have it be provided with the HTTPBIN_URL value instead of the value being read from the global variable.

To reproduce flakiness:

* Install pytest-flakefinder by following the instructions [here](https://github.com/dropbox/pytest-flakefinder).
* At root directory, run `pytest --flake-finder test/test_noipy.py::SanityTest::test_get_ip`

After implementing the fix, all tests pass successfully, both with and without the [pytest-flakefinder](https://github.com/dropbox/pytest-flakefinder) plugin being used.

In general, flaky tests are a pain to fix with regards to locating the root of the actual problem, so it's a good idea to fix them when you detect them. I'm aware that the tests might not be re-run at all, but this change makes the entire module more robust and future-proof so it's just a small fix for you to consider.