### PR TITLE
Add support to change the source IP.

### DIFF
--- a/noipy/main.py
+++ b/noipy/main.py
@@ -107,7 +107,7 @@ def execute_update(args):
     response_code = None
     response_text = None
     if update_ddns:
-        ip_address = args.ip if args.ip else utils.get_ip()
+        ip_address = args.ip if args.ip else utils.get_ip(args.sourceip)
         if not ip_address:
             process_message = 'Unable to get IP address. Check connection.'
             exec_result = EXECUTION_RESULT_NOK
@@ -137,6 +137,7 @@ def create_parser():
     parser.add_argument('-u', '--usertoken', help='provider username or token')
     parser.add_argument('-p', '--password', help='provider password when apply')
     parser.add_argument('-n', '--hostname', help='provider hostname to be updated')
+    parser.add_argument('-s', '--sourceip', help='source ip to use')
     parser.add_argument(
         '--provider',
         help='DDNS provider plugin (default: {})'.format(dnsupdater.DEFAULT_PLUGIN),

--- a/noipy/utils.py
+++ b/noipy/utils.py
@@ -8,6 +8,7 @@
 import socket
 
 import requests
+from requests_toolbelt.adapters import source
 
 HTTPBIN_URL = 'https://httpbin.org/ip'
 
@@ -21,10 +22,14 @@ def read_input(message):
     return input(message)
 
 
-def get_ip():
+def get_ip(source_ip):
     """Return machine's origin IP address."""
     try:
-        r = requests.get(HTTPBIN_URL)
+        s = requests.Session()
+        new_source = source.SourceAddressAdapter(source_ip)
+        s.mount('http://', new_source)
+        s.mount('https://', new_source)
+        r = s.get(HTTPBIN_URL)
         return r.json()['origin'] if r.status_code == 200 else None
     except requests.exceptions.ConnectionError:
         return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.27.1
+requests-toolbelt=0.10.1


### PR DESCRIPTION
The sourceip argument will add support to change the source ip of the requests call. This will enable the possibility of update different hosts using different source IP. In my case I have 2 hosts to updated and 2 internet connections. Each host have to be updated using one of the different IPs.

Example:
./noipy -n HOSTNAME1 --provider {noip,dyn,duck,generic} --sourceip SOURCEIP1
./noipy -n HOSTNAME2 --provider {noip,dyn,duck,generic} --sourceip SOURCEIP2