### PR TITLE
Fx Release Drafter permissions to resolve integration access error

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,6 +16,9 @@ permissions:
 
 jobs:
   update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
- Add missing job-level permissions to Release Drafter workflow
- Grant `contents: write` and `pull-requests: write` permissions to the `update_release_draft` job
