### PR TITLE
Add PyPI publish workflow with Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+    if: github.event.release.prerelease == false
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: github.event.release.prerelease == false
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/noipy
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
  - Add GitHub Action workflow to automatically
   publish package to PyPI when releases are
  published
  - Use OpenID Connect (OIDC) for secure
  authentication without API tokens
  - Build and publish only for non-prerelease
  versions

  ## Changes
  - New workflow file:
  `.github/workflows/publish.yml`
  - Triggers on release publication events
  - Uses artifact upload/download pattern for
  clean separation between build and publish
  jobs
  - Implements PyPI Trusted Publishing for
  secure, token-free authentication
