### PR TITLE
Enhance release drafter with changelog links and asset uploads

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,4 @@
-name-template: 'v$RESOLVED_VERSION'
+name-template: 'noipy v$RESOLVED_VERSION (date: $CURRENT_DATE)'
 tag-template: 'v$RESOLVED_VERSION'
 categories:
   - title: '🚀 Features'
@@ -98,6 +98,8 @@ template: |
   ## 🚀 Release $RESOLVED_VERSION
 
   $CHANGES
+
+  **[Full Changelog](https://github.com/pv8/noipy/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION)**
 
   ### 📦 Installation
   ```bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,28 @@ jobs:
         name: python-package-distributions
         path: dist/
 
+  upload-assets:
+    name: Upload release assets
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event.release.prerelease == false
+    permissions:
+      contents: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Upload assets to release
+      run: |
+        for file in dist/*; do
+          gh release upload "${{ github.event.release.tag_name }}" "$file" --clobber
+        done
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
@@ -43,8 +65,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/noipy
     permissions:
-      id-token: write
-
+      id-token: write  # Needed to access the workflow's OIDC identity.
     steps:
     - name: Download all the dists
       uses: actions/download-artifact@v4


### PR DESCRIPTION
# Summary
  - Improve release drafter title format to include project name and date
  - Add full changelog comparison link between versions in release notes
  - Add automatic release asset upload (wheel and source distribution) when releases are published

  ## Changes Made
  - **Release Drafter Configuration**: Updated title template and added changelog comparison link
  - **Publish Workflow**: Added `upload-assets` job to automatically attach distribution files to GitHub releases