### PR TITLE
Drop Python 3.8 support (EOL)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py{38,39,310,311,312,313},pypy3,pep8
+envlist = py{39,310,311,312,313},pypy3,pep8
 
 [testenv]
 passenv = CI,TRAVIS_BUILD_ID,TRAVIS,TRAVIS_BRANCH,TRAVIS_JOB_NUMBER,TRAVIS_PULL_REQUEST,TRAVIS_JOB_ID,TRAVIS_REPO_SLUG,TRAVIS_COMMIT
 deps =
     -rrequirements-dev.txt
-    py{38,39,310,311,312,313},pypy3: coverage
+    py{39,310,311,312,313},pypy3: coverage
 
 commands =
     python --version


### PR DESCRIPTION
This PR drops support for Python 3.8 which has reached end-of-life. This is a maintenance change to clean up the codebase and focus on supported Python versions.

## Changes
- Remove Python 3.8 from tox environment list
- Remove Python 3.8 from setup.py classifiers  
- Remove Python 3.8 from GitHub Actions workflow matrix

## Why
Python 3.8 reached end-of-life on October 14, 2024. This change helps maintain a cleaner, more focused codebase by removing support for EOL Python versions.