### PR TITLE
Optimize CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Tests
+name: CI
 
 on:
   push:
@@ -11,6 +11,7 @@ on:
 
 jobs:
   lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -31,6 +32,7 @@ jobs:
         flake8 noipy/ tests/ --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics
 
   type-check:
+    name: Type Check
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -48,6 +50,7 @@ jobs:
         mypy
 
   test:
+    name: Test - ${{ matrix.os }} / Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,35 +10,63 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+        cache: 'pip'
+    - name: Install lint dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[lint]"
+    - name: Run linter
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 noipy/ tests/ --count --select=E9,F63,F7,F82 --show-source --statistics
+        # non-blocking errors
+        flake8 noipy/ tests/ --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics
 
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+        cache: 'pip'
+    - name: Install type checking dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[typing]"
+    - name: Run type checking
+      run: |
+        mypy
+
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+        cache: 'pip'
+    - name: Install test dependencies
       run: |
         python -m pip install --upgrade pip
         pip install coverage
-        pip install -e ".[tests,lint,typing]"
-    - name: Run linter
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Run type checking
-      run: |
-        mypy
+        pip install -e ".[tests]"
     - name: Run tests
       run: |
         pytest -v --cov=. --cov-report term-missing --cov-report xml --junitxml=junit.xml -o junit_family=legacy

--- a/README.rst
+++ b/README.rst
@@ -2,9 +2,9 @@ noipy: DDNS update tool
 =======================
 
 
-.. image:: https://github.com/pv8/noipy/actions/workflows/tests.yml/badge.svg
-    :target: https://github.com/pv8/noipy/actions/workflows/tests.yml
-    :alt: Tests
+.. image:: https://github.com/pv8/noipy/actions/workflows/ci.yml/badge.svg
+    :target: https://github.com/pv8/noipy/actions/workflows/ci.yml
+    :alt: CI
 
 .. image:: https://img.shields.io/pypi/v/noipy.svg
     :target: https://pypi.python.org/pypi/noipy/


### PR DESCRIPTION
- Split linting, type checking, and testing into separate parallel jobs for faster CI
- Rename workflow from tests.yml to ci.yml to better reflect its purpose 